### PR TITLE
fix: QA #7 데모 버튼 색상을 빨간색으로 변경해주세요.

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -111,7 +111,7 @@ a:hover {
 }
 
 .demo-button {
-  background: var(--primary);
+  background: var(--danger);
   color: white;
   border: none;
   padding: 0.75rem 1.5rem;
@@ -121,7 +121,7 @@ a:hover {
 }
 
 .demo-button:hover {
-  background: var(--primary-hover);
+  background: #dc2626;
 }
 
 /* QA Page */


### PR DESCRIPTION
## QA 요청 (Issue #7)

**제목**: 데모 버튼 색상을 빨간색으로 변경해주세요.
**상세**: 데모 버튼 색상을 빨간색으로 변경해주세요.

---

## 분석
데모 버튼(`.demo-button`)의 배경색을 빨간색으로 변경하는 요청입니다.

## 수정 계획
`app/globals.css`의 `.demo-button` 스타일만 수정. 기존에 정의된 CSS 변수 `--danger: #ef4444`(빨간색)를 활용합니다.

## 변경 내용
- `.demo-button`의 `background`를 `var(--primary)`(파란색) → `var(--danger)`(빨간색 `#ef4444`)로 변경
- `.demo-button:hover`의 `background`를 `var(--primary-hover)` → `#dc2626`(더 어두운 빨간색)으로 변경

---

Claude Code가 자동으로 생성한 PR입니다.
close #7